### PR TITLE
Get dynamically version during build time

### DIFF
--- a/hash-addressed-cli/hash-addressed-cli.cabal
+++ b/hash-addressed-cli/hash-addressed-cli.cabal
@@ -35,6 +35,8 @@ common base
         LambdaCase
         NamedFieldPuns
         NoImplicitPrelude
+    other-modules:
+        Paths_hash_addressed_cli
     build-depends:
       , base ^>= 4.16 || ^>= 4.17
       , bytestring ^>= 0.11.3

--- a/hash-addressed-cli/library/HashAddressed/App/Version.hs
+++ b/hash-addressed-cli/library/HashAddressed/App/Version.hs
@@ -1,10 +1,15 @@
+{-# LANGUAGE CPP             #-}
+{-# LANGUAGE TemplateHaskell #-}
+
 module HashAddressed.App.Version
   (
-    version,
+    HashAddressed.App.Version.version
   )
   where
 
+import Data.Version (showVersion)
+import Paths_hash_addressed_cli as P (version)
 import Prelude (String)
 
 version :: String
-version = "2"
+version = showVersion P.version


### PR DESCRIPTION
A very small enhancement to get dynamically version from hash-addressed-cli.cabal during build time.

_N.B._ : I have tried to add extensions to default-extensions but CPP raised issues. 